### PR TITLE
mark FC plugin as replacement for TC plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "phpunit/phpunit": "*",
     "phpunit/phpunit-selenium": ">=1.2"
   },
+  "replace": {
+    "topconcepts/oxid-klarna-6": "*"
+  },
   "autoload": {
     "psr-4": {
       "TopConcepts\\Klarna\\": "./"


### PR DESCRIPTION
Even the current metapackage of the OXID shop (6.4.2) refers to the discontinued TC module. To switch to your module, it must be installed in parallel. This leads to double installations of an identical module. Uninstalling the TC module is not possible due to the defined dependency. Only by a coincidentally favourable constellation will the appropriate module be copied into the shop.

If your plug-in knows the dependency that it is the replacement for the TC module, you can switch to it cleanly without difficulty. The duplications are then resolved and incorrect installation is impossible.

```
Package operations: 1 install, 0 updates, 1 removal
  - Downloading fatchip-gmbh/oxid-klarna-6 (v5.5.2)
  - Removing topconcepts/oxid-klarna-6 (v5.5.2)
```