### PR TITLE
Fix class chain fixation during the module installation

### DIFF
--- a/Core/KlarnaInstaller.php
+++ b/Core/KlarnaInstaller.php
@@ -23,6 +23,7 @@ use OxidEsales\Eshop\Application\Model\Actions;
 use OxidEsales\Eshop\Application\Model\Payment;
 use OxidEsales\Eshop\Core\DatabaseProvider;
 use OxidEsales\Eshop\Core\DbMetaDataHandler;
+use OxidEsales\Eshop\Core\Model\BaseModel;
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Field;
 use OxidEsales\Eshop\Core\Database\Adapter\Doctrine\Database;
@@ -198,26 +199,28 @@ class KlarnaInstaller extends ShopConfiguration
      */
     protected function addKlarnaPaymentsMethods()
     {
-        $oPayment = oxNew(Payment::class);
+        $oPayment = oxNew(BaseModel::class);
+        $oPayment->init('oxpayments');
 
         $oPayment->load('oxidinvoice');
         $de_prefix = $oPayment->getFieldData('oxdesc') === 'Rechnung' ? 0 : 1;
         $en_prefix = $de_prefix === 1 ? 0 : 1;
 
-        $newPayments = array(KlarnaPayment::KLARNA_PAYMENT_CHECKOUT_ID  =>
-                                 array($de_prefix => 'Klarna Checkout', $en_prefix => 'Klarna Checkout'),
-                             KlarnaPayment::KLARNA_PAYMENT_PAY_LATER_ID =>
-                                 array($de_prefix => 'Klarna Rechnung', $en_prefix => 'Klarna Pay Later'),
-                             KlarnaPayment::KLARNA_PAYMENT_SLICE_IT_ID  =>
-                                 array($de_prefix => 'Klarna Ratenkauf', $en_prefix => 'Klarna Financing'),
-                             KlarnaPayment::KLARNA_PAYMENT_PAY_NOW =>
-                                 array($de_prefix => 'Klarna Sofort bezahlen', $en_prefix => 'Klarna Pay Now'),
-                             KlarnaPayment::KLARNA_DIRECTDEBIT =>
-                                 array($de_prefix => 'Klarna Lastschrift', $en_prefix => 'Klarna Direct Debit'),
-                             KlarnaPayment::KLARNA_CARD =>
-                                 array($de_prefix => 'Klarna Kreditkarte', $en_prefix => 'Klarna Card'),
-                             KlarnaPayment::KLARNA_SOFORT =>
-                                 array($de_prefix => 'Klarna Sofortüberweisung', $en_prefix => 'Klarna Online Bank Transfer'),
+        $newPayments = array(
+            KlarnaPaymentTypes::KLARNA_PAYMENT_CHECKOUT_ID  =>
+                array($de_prefix => 'Klarna Checkout', $en_prefix => 'Klarna Checkout'),
+            KlarnaPaymentTypes::KLARNA_PAYMENT_PAY_LATER_ID =>
+                array($de_prefix => 'Klarna Rechnung', $en_prefix => 'Klarna Pay Later'),
+            KlarnaPaymentTypes::KLARNA_PAYMENT_SLICE_IT_ID  =>
+                array($de_prefix => 'Klarna Ratenkauf', $en_prefix => 'Klarna Financing'),
+            KlarnaPaymentTypes::KLARNA_PAYMENT_PAY_NOW =>
+                array($de_prefix => 'Klarna Sofort bezahlen', $en_prefix => 'Klarna Pay Now'),
+            KlarnaPaymentTypes::KLARNA_DIRECTDEBIT =>
+                array($de_prefix => 'Klarna Lastschrift', $en_prefix => 'Klarna Direct Debit'),
+            KlarnaPaymentTypes::KLARNA_CARD =>
+                array($de_prefix => 'Klarna Kreditkarte', $en_prefix => 'Klarna Card'),
+            KlarnaPaymentTypes::KLARNA_SOFORT =>
+                array($de_prefix => 'Klarna Sofortüberweisung', $en_prefix => 'Klarna Online Bank Transfer'),
         );
 
         $sort   = -350;
@@ -226,7 +229,9 @@ class KlarnaInstaller extends ShopConfiguration
         if ($aLangs) {
             foreach ($newPayments as $oxid => $aTitle) {
                 /** @var Payment $oPayment */
-                $oPayment = oxNew(Payment::class);
+                $oPayment = oxNew(BaseModel::class);
+                $oPayment->init('oxpayments');
+
                 $oPayment->load($oxid);
                 if ($oPayment->isLoaded()) {
                     $oPayment->oxpayments__oxactive = new Field(1, Field::T_RAW);
@@ -234,7 +239,7 @@ class KlarnaInstaller extends ShopConfiguration
 
                     continue;
                 }
-                $oPayment->setEnableMultilang(false);
+//                $oPayment->setEnableMultilang(false);
                 $oPayment->setId($oxid);
                 $oPayment->oxpayments__oxactive      = new Field(1, Field::T_RAW);
                 $oPayment->oxpayments__oxaddsum      = new Field(0, Field::T_RAW);

--- a/Core/KlarnaPaymentTypes.php
+++ b/Core/KlarnaPaymentTypes.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright 2018 Klarna AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace TopConcepts\Klarna\Core;
+
+class KlarnaPaymentTypes extends KlarnaClientBase
+{
+    /**
+     * Oxid value of Klarna Part payment
+     *
+     * @var string
+     */
+    const KLARNA_PAYMENT_SLICE_IT_ID = 'klarna_slice_it';
+
+    /**
+     * Oxid value of Klarna Invoice payment
+     *
+     * @var string
+     */
+    const KLARNA_PAYMENT_PAY_LATER_ID = 'klarna_pay_later';
+
+    /**
+     * Oxid value of Klarna Checkout payment
+     *
+     * @var string
+     */
+    const KLARNA_PAYMENT_CHECKOUT_ID = 'klarna_checkout';
+
+    /**
+     * Oxid value of Klarna Pay Now payment
+     *
+     * @var string
+     */
+    const KLARNA_PAYMENT_PAY_NOW = 'klarna_pay_now';
+
+    /**
+     * Oxid value of Klarna Pay Now payment
+     *
+     * @var string
+     */
+    const KLARNA_DIRECTDEBIT = 'klarna_directdebit';
+
+    /**
+     * Oxid value of Klarna card
+     *
+     * @var string
+     */
+    const KLARNA_CARD = 'klarna_card';
+
+    /**
+     * Oxid value of Klarna Pay Now payment
+     *
+     * @var string
+     */
+    const KLARNA_SOFORT = 'klarna_sofort';
+}

--- a/Tests/Unit/Controller/KlarnaOrderControllerTest.php
+++ b/Tests/Unit/Controller/KlarnaOrderControllerTest.php
@@ -134,7 +134,7 @@ class KlarnaOrderControllerTest extends ModuleUnitTestCase
         $user->expects($this->once())->method('onOrderExecute')->willReturn(true);
 
         $oBasket = $this->getMockBuilder(KlarnaBasket::class)->setMethods(['getPaymentId', 'calculateBasket'])->getMock();
-        $oBasket->expects($this->once())->method('getPaymentId')->willReturn('klarna_checkout');
+        $oBasket->expects($this->atLeastOnce())->method('getPaymentId')->willReturn('klarna_checkout');
         $oBasket->expects($this->once())->method('calculateBasket')->willReturn(true);
         $sut = $this->getMockBuilder(OrderController::class)
             ->setMethods(['kcoBeforeExecute', 'getDeliveryAddressMD5', 'klarnaCheckoutSecurityCheck'])
@@ -185,7 +185,7 @@ class KlarnaOrderControllerTest extends ModuleUnitTestCase
     public function testExecuteFails($sGetChallenge, $requestId, $sessionId, $statusData, $kcoExecuteCount, $expectedResult)
     {
         $oBasket = $this->getMockBuilder(KlarnaBasket::class)->setMethods(['getPaymentId'])->getMock();
-        $oBasket->expects($this->once())->method('getPaymentId')->willReturn('klarna_checkout');
+        $oBasket->expects($this->atLeastOnce())->method('getPaymentId')->willReturn('klarna_checkout');
         $sut = $this->getMockBuilder(OrderController::class)->setMethods(['kcoBeforeExecute', 'kcoExecute'])->getMock();
         $sut->expects($this->exactly($kcoExecuteCount))->method('kcoBeforeExecute');
         $sut->expects($this->exactly($kcoExecuteCount))->method('kcoExecute');

--- a/Tests/Unit/Controller/KlarnaOrderControllerTest.php
+++ b/Tests/Unit/Controller/KlarnaOrderControllerTest.php
@@ -781,27 +781,28 @@ class KlarnaOrderControllerTest extends ModuleUnitTestCase
 
     public function updateKlarnaOrderDataProvider()
     {
-        $oUser = oxNew(User::class);
-        $aOrderData = [
+        $orderData = [
             'billing_address' => 'testValue_1',
             'shipping_address' => 'testValue_2'
         ];
 
         return [
-            [$oUser, 1, $aOrderData],
-            [$oUser, 1, []],
-            [null, 0, $aOrderData],
+            ['user', 1, $orderData],
+            ['user', 1, []],
+            [null, 0, $orderData],
         ];
     }
 
     /**
      * @dataProvider updateKlarnaOrderDataProvider
-     * @param $oUser
+     * @param string $setUser
      * @param $updatedCallsCount
      * @param $aOrderData
      */
-    public function testUpdateKlarnaOrder($oUser, $updatedCallsCount, $aOrderData)
+    public function testUpdateKlarnaOrder($setUser, $updatedCallsCount, $aOrderData)
     {
+        $oUser = ('user' === $setUser) ? oxNew(User::class) : null;
+
         // tested by calling updateKlarnaAjax
         $oClient = $this->getMockBuilder(KlarnaCheckoutClient::class)->setMethods(['createOrUpdateOrder'])->getMock();
         $oClient->expects($this->exactly($updatedCallsCount))->method('createOrUpdateOrder')->with(
@@ -959,7 +960,7 @@ class KlarnaOrderControllerTest extends ModuleUnitTestCase
         $user = $this->getMockBuilder(KlarnaUser::class)->setMethods(['resolveCountry'])->getMock();
         $user->expects($this->once())->method('resolveCountry')->willReturn('DE');
         $sut = $this->getMockBuilder(KlarnaOrderController::class)->setMethods(['getUser', 'getJsonRequest'])->getMock();
-                $sut->expects($this->once())->method('getUser')->willReturn($user);
+        $sut->expects($this->once())->method('getUser')->willReturn($user);
         $sut->expects($this->once())->method('getJsonRequest')->willReturn(['action' => 'checkOrderStatus']);
 
         $sut->updateKlarnaAjax();


### PR DESCRIPTION
The usage of oxNew during the module activation is a very bad idea as it triggers some states to be cached and then other modules cannot appear in the chain before some cleanups done.

I would recommend fully removing the database manipulation from the module activation event and use migrations for doing this.

This pull request just fixes the oxPayment class chain fixation and allows running the shop compilation tests with other modules. This is a Temporary solution, not final.